### PR TITLE
Make RigidBody rotate on mouse movement

### DIFF
--- a/entities/player/player.tscn
+++ b/entities/player/player.tscn
@@ -25,9 +25,7 @@ shape = SubResource("CapsuleShape3D_vee4a")
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 1.4, 0)
 script = ExtResource("2_6cr3v")
 
-[node name="VerticalAxis" type="Node3D" parent="CameraPivot"]
-
-[node name="Camera3D" type="Camera3D" parent="CameraPivot/VerticalAxis"]
+[node name="Camera3D" type="Camera3D" parent="CameraPivot"]
 current = true
 
 [node name="GroundRayCast3D" type="RayCast3D" parent="."]

--- a/entities/player/scripts/player_base.gd
+++ b/entities/player/scripts/player_base.gd
@@ -7,14 +7,19 @@ extends RigidDynamicBody3D
 
 @onready var _camera_pivot: Node3D = $CameraPivot
 @onready var _ground_ray_cast: RayCast3D = $GroundRayCast3D
+@onready var _rotation_y = rotation.y
 
 var _current_jump := 0
 var _air_time := 0.0
+var _event_relative_x = 0.0
 var is_jumping := false
 
 
 func _ready() -> void:
 	Input.set_mouse_mode(Input.MOUSE_MODE_CAPTURED)
+
+func _input(event: InputEvent) -> void:
+	mouse_movement(event)
 
 func _physics_process(delta: float) -> void:
 	air_time(delta)
@@ -24,7 +29,19 @@ func _integrate_forces(state: PhysicsDirectBodyState3D) -> void:
 
 
 
+func mouse_movement(event: InputEvent) -> void:
+	if event is InputEventMouseMotion and Input.get_mouse_mode() == Input.MOUSE_MODE_CAPTURED:
+		_camera_pivot.rotation.x -= event.relative.y * mouse_sensitivity
+		_camera_pivot.rotation.x = clamp(_camera_pivot.rotation.x, deg2rad(-80), deg2rad(80))
+		
+		_rotation_y -= event.relative.x * mouse_sensitivity
+		_rotation_y = wrapf(_rotation_y, 0, deg2rad(360))
+
+
 func character_movement(state: PhysicsDirectBodyState3D) -> void:
+	# Rotate the character Y based on mouse horizontal movement
+	rotation.y = _rotation_y
+	
 	# Reset the number of jumps on touch the floor
 	if _ground_ray_cast.is_colliding() and _air_time > 0.1:
 		is_jumping = false
@@ -42,7 +59,7 @@ func character_movement(state: PhysicsDirectBodyState3D) -> void:
 
 	# Get the input direction and handle the movement/deceleration.
 	var input_dir = Input.get_vector("a_left", "a_right", "a_up", "a_down")
-	var direction = (_camera_pivot.global_transform.basis * Vector3(input_dir.x, 0, input_dir.y)).normalized()
+	var direction = (transform.basis * Vector3(input_dir.x, 0, input_dir.y)).normalized()
 	
 	if direction:
 		state.linear_velocity.x = direction.x * speed

--- a/entities/player/scripts/player_camera.gd
+++ b/entities/player/scripts/player_camera.gd
@@ -1,21 +1,8 @@
 extends Position3D
 
-@onready var player: RigidDynamicBody3D = get_parent()
-@onready var _vertical_axis: Node3D = $VerticalAxis
-
 func _input(event: InputEvent) -> void:
-	mouse_movement(event)
-	
 	if Input.is_action_just_pressed("a_toggle_mouse_lock"):
 		toggle_mouse_lock()
-
-func mouse_movement(event: InputEvent) -> void:
-	if event is InputEventMouseMotion and Input.get_mouse_mode() == Input.MOUSE_MODE_CAPTURED:
-		_vertical_axis.rotation.x -= event.relative.y * player.mouse_sensitivity
-		_vertical_axis.rotation.x = clamp(_vertical_axis.rotation.x, deg2rad(-80), deg2rad(80))
-
-		rotation.y -= event.relative.x * player.mouse_sensitivity
-		rotation.y = wrapf(rotation.y, 0, deg2rad(360))
 
 func toggle_mouse_lock() -> void:
 	if Input.get_mouse_mode() == Input.MOUSE_MODE_CAPTURED:


### PR DESCRIPTION
Restore the behavior that match Godot 4.0 Alpha 10.

I'm rotating the Rigid Body (rotation.y) to face the player movement, that's a decision to make implement some gameplay logic easier.